### PR TITLE
fix tmElements_t has not been declared

### DIFF
--- a/DS1337RTC.h
+++ b/DS1337RTC.h
@@ -6,7 +6,7 @@
 #ifndef DS1337RTC_h
 #define DS1337RTC_h
 
-#include <Time.h>
+#include <TimeLib.h>
 
 #define DS1337_CTRL_ID 0x68
 #define CLOCK_ADDRESS 0x00


### PR DESCRIPTION
Using the ESP8266 SDK 2.4.1 and i have this error on the compilation : tmElements_t has not been declared.

Time.h was changed to TimeLib.h specifically to combat this problem. The compiler started providing time.h, and on operating systems like Windows that use a case-insensitive filesystem it confuses Time.h and time.h.
https://arduino.stackexchange.com/questions/43632/tmelements-t-does-not-name-a-type
https://github.com/PaulStoffregen/DS1307RTC/issues/10