### PR TITLE
Add Oscillator Stop Flag (OSF)

### DIFF
--- a/DS1337RTC.cpp
+++ b/DS1337RTC.cpp
@@ -56,6 +56,20 @@ time_t DS1337RTC::sync()  // Function to use for Time.h setSyncProvider
   return(get(CLOCK_ADDRESS));
 }
 
+bool DS1337RTC::readOSF() // Aquire data from the RTC chip in BCD format
+{
+  Wire.beginTransmission(DS1337_CTRL_ID);
+  Wire.write(STATUS_ADDRESS);
+  Wire.endTransmission();
+  Wire.requestFrom(DS1337_CTRL_ID, 1);
+  uint8_t status = bitRead(Wire.read(), 7);
+  if(status==0x01){
+    return(true);
+  }else if (status == 0x00){
+    return(false);
+  }
+}
+
 void DS1337RTC::read( tmElements_t &tm, int address) // Aquire data from the RTC chip in BCD format
 {
   int numberBytes;

--- a/DS1337RTC.h
+++ b/DS1337RTC.h
@@ -6,7 +6,7 @@
 #ifndef DS1337RTC_h
 #define DS1337RTC_h
 
-#include <Time.h>
+#include <TimeLib.h>
 
 #define DS1337_CTRL_ID 0x68
 #define CLOCK_ADDRESS 0x00

--- a/DS1337RTC.h
+++ b/DS1337RTC.h
@@ -33,6 +33,7 @@ class DS1337RTC
     static void resetAlarms();
     static void interruptSelect(int mode);
     static void freqSelect(int freq);
+    bool readOSF();
 
   private:
     static uint8_t dec2bcd(uint8_t num);


### PR DESCRIPTION
When the RTC's oscillator has stopped (e.g dead battery), a flag is set.

Thus we can decide not to trust the RTC timestamp and synchronize it with some other source (e.g NTP)